### PR TITLE
[8.2] Correctly use display name in notifications and when announcing

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -48,6 +48,7 @@ use OCA\AnnouncementCenter\NotificationsNotifier;
 \OC::$server->getNotificationManager()->registerNotifier(function() {
 	return new NotificationsNotifier(
 		new Manager(\OC::$server->getDatabaseConnection()),
-		\OC::$server->getL10NFactory()
+		\OC::$server->getL10NFactory(),
+		\OC::$server->getUserManager()
 	);
 });

--- a/js/script.js
+++ b/js/script.js
@@ -70,7 +70,7 @@
 
 				var $html = $(compiledTemplate({
 					time: OC.Util.formatDate(announcement.time * 1000),
-					author: OC.currentUser,
+					author: announcement.author,
 					subject: announcement.subject,
 					message: announcement.message,
 					announcementId: (oc_isadmin) ? announcement.id : 0

--- a/lib/notificationsnotifier.php
+++ b/lib/notificationsnotifier.php
@@ -24,6 +24,8 @@ namespace OCA\AnnouncementCenter;
 
 use OC\Notification\INotification;
 use OC\Notification\INotifier;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 
 class NotificationsNotifier implements INotifier {
@@ -34,12 +36,17 @@ class NotificationsNotifier implements INotifier {
 	/** @var Manager */
 	protected $manager;
 
+	/** @var IUserManager */
+	protected $userManager;
+
 	/**
 	 * @param Manager $manager
 	 * @param IFactory $l10nFactory
+	 * @param IUserManager $userManager
 	 */
-	public function __construct(Manager $manager, IFactory $l10nFactory) {
+	public function __construct(Manager $manager, IFactory $l10nFactory, IUserManager $userManager) {
 		$this->manager = $manager;
+		$this->userManager = $userManager;
 		$this->l10nFactory = $l10nFactory;
 	}
 
@@ -62,6 +69,10 @@ class NotificationsNotifier implements INotifier {
 			// Deal with known subjects
 			case 'announced':
 				$params = $notification->getSubjectParameters();
+				$user = $this->userManager->get($params[0]);
+				if ($user instanceof IUser) {
+					$params[0] = $user->getDisplayName();
+				}
 
 				$announcement = $this->manager->getAnnouncement($notification->getObjectId(), false);
 				$params[] = $this->prepareMessage($announcement['subject']);

--- a/tests/lib/NotificationsNotifierTest.php
+++ b/tests/lib/NotificationsNotifierTest.php
@@ -25,6 +25,7 @@ use OCA\AnnouncementCenter\NotificationsNotifier;
 use OCA\AnnouncementCenter\Manager;
 use OCA\AnnouncementCenter\Tests\TestCase;
 use OCP\IL10N;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 
 class NotificationsNotifierTest extends TestCase {
@@ -33,6 +34,8 @@ class NotificationsNotifierTest extends TestCase {
 
 	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $manager;
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
 	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
 	protected $factory;
 	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
@@ -42,6 +45,9 @@ class NotificationsNotifierTest extends TestCase {
 		parent::setUp();
 
 		$this->manager = $this->getMockBuilder('OCA\AnnouncementCenter\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l = $this->getMockBuilder('OCP\IL10N')
@@ -61,7 +67,8 @@ class NotificationsNotifierTest extends TestCase {
 
 		$this->notifier = new NotificationsNotifier(
 			$this->manager,
-			$this->factory
+			$this->factory,
+			$this->userManager
 		);
 	}
 
@@ -102,14 +109,26 @@ class NotificationsNotifierTest extends TestCase {
 		$this->notifier->prepare($notification, 'en');
 	}
 
+	/**
+	 * @return \OCP\IUser|\PHPUnit_Framework_MockObject_Builder_InvocationMocker
+	 */
+	protected function getUserMock() {
+		$user = $this->getMock('OCP\IUser');
+		$user->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Author');
+		return $user;
+	}
+
 	public function dataPrepare() {
 		$subject = "subject\nsubject subject subject subject subject subject subject subject subject subject subject subject subject subject subject subject subject subject";
 		$subjectTrim = 'subject subject subject subject subject subject subject subject subject subject subject subject subject…';
 		$message = "message\nmessage message message message message message message message message message message messagemessagemessagemessagemessagemessagemessage";
 		$messageTrim = 'message message message message message message message message message message message message messagemessagemessagemes…';
 		return [
-			['author', 'subject', 'message', 42, 'author announced “subject”', 'message'],
-			['author2', $subject, $message, 21, 'author2 announced “' . $subjectTrim . '”', $messageTrim],
+			['author', 'subject', 'message', 42, null, 'author announced “subject”', 'message'],
+			['author1', 'subject', 'message', 42, $this->getUserMock(), 'Author announced “subject”', 'message'],
+			['author2', $subject, $message, 21, null, 'author2 announced “' . $subjectTrim . '”', $messageTrim],
 		];
 	}
 
@@ -120,10 +139,11 @@ class NotificationsNotifierTest extends TestCase {
 	 * @param string $subject
 	 * @param string $message
 	 * @param int $objectId
+	 * @param \OCP\IUser $userObject
 	 * @param string $expectedSubject
 	 * @param string $expectedMessage
 	 */
-	public function testPrepare($author, $subject, $message, $objectId, $expectedSubject, $expectedMessage) {
+	public function testPrepare($author, $subject, $message, $objectId, $userObject, $expectedSubject, $expectedMessage) {
 		/** @var \OC\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
 		$notification = $this->getMockBuilder('OC\Notification\INotification')
 			->disableOriginalConstructor()
@@ -149,6 +169,10 @@ class NotificationsNotifierTest extends TestCase {
 				'subject' => $subject,
 				'message' => $message,
 			]);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($author)
+			->willReturn($userObject);
 
 		$notification->expects($this->once())
 			->method('setParsedMessage')


### PR DESCRIPTION
Backport #60 