### PR TITLE
Add coding standard test in drone and fix code style

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -157,6 +157,13 @@ services:
 
 matrix:
   include:
+    # owncloud coding standard
+    - PHP_VERSION: 7.1
+      TEST_SUITE: owncloud-coding-standard
+
+    - PHP_VERSION: 5.6
+      TEST_SUITE: owncloud-coding-standard
+
     # code check tests
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -21,13 +21,13 @@
 
 $app = new \OCA\AnnouncementCenter\AppInfo\Application();
 
-\OC::$server->getActivityManager()->registerExtension(function() use ($app) {
+\OC::$server->getActivityManager()->registerExtension(function () use ($app) {
 	return $app->getContainer()->query('OCA\AnnouncementCenter\Activity\Extension');
 });
 
-\OC::$server->getNotificationManager()->registerNotifier(function() use ($app) {
+\OC::$server->getNotificationManager()->registerNotifier(function () use ($app) {
 	return $app->getContainer()->query('OCA\AnnouncementCenter\Notification\Notifier');
-}, function() use ($app) {
+}, function () use ($app) {
 	$l = $app->getContainer()->getServer()->getL10NFactory()->get('announcementcenter');
 	return [
 		'id' => 'announcementcenter',

--- a/lib/Activity/Extension.php
+++ b/lib/Activity/Extension.php
@@ -94,7 +94,7 @@ class Extension implements IExtension {
 		if ($app === 'announcementcenter') {
 			$l = $this->languageFactory->get('announcementcenter', $languageCode);
 
-			list(, $id) = explode('#', $text);
+			list(, $id) = \explode('#', $text);
 
 			try {
 				$announcement = $this->manager->getAnnouncement($id, true);
@@ -102,7 +102,7 @@ class Extension implements IExtension {
 				return (string) $l->t('Announcement does not exist anymore', $params);
 			}
 
-			if (strpos($text, 'announcementmessage#') === 0) {
+			if (\strpos($text, 'announcementmessage#') === 0) {
 				return $announcement['message'];
 			}
 
@@ -110,7 +110,7 @@ class Extension implements IExtension {
 
 			try {
 				if ($announcement['author'] === $this->activityManager->getCurrentUserId()) {
-					array_shift($params);
+					\array_shift($params);
 					return (string) $l->t('You announced %s', $params);
 				}
 			} catch (\UnexpectedValueException $e) {
@@ -134,7 +134,7 @@ class Extension implements IExtension {
 	 * @return array|false
 	 */
 	public function getSpecialParameterList($app, $text) {
-		if ($app === 'announcementcenter'&& strpos($text, 'announcementsubject#') === 0) {
+		if ($app === 'announcementcenter'&& \strpos($text, 'announcementsubject#') === 0) {
 			return [
 				0 => 'username',
 			];
@@ -183,7 +183,7 @@ class Extension implements IExtension {
 	 * @return array|false
 	 */
 	public function filterNotificationTypes($types, $filter) {
-		if (in_array($filter, ['all', 'by', 'self'])) {
+		if (\in_array($filter, ['all', 'by', 'self'])) {
 			$types[] = 'announcementcenter';
 			return $types;
 		}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,11 +29,11 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class Application extends App {
-	public function __construct (array $urlParams = array()) {
+	public function __construct(array $urlParams = []) {
 		parent::__construct('announcementcenter', $urlParams);
 		$container = $this->getContainer();
 
-		$container->registerService('PageController', function(IContainer $c) {
+		$container->registerService('PageController', function (IContainer $c) {
 			/** @var \OC\Server $server */
 			$server = $c->query('ServerContainer');
 

--- a/lib/BackgroundJob.php
+++ b/lib/BackgroundJob.php
@@ -99,7 +99,7 @@ class BackgroundJob extends QueuedJob {
 			->setSubject('announced', [$authorId])
 			->setLink($this->urlGenerator->linkToRoute('announcementcenter.page.index'));
 
-		$this->userManager->callForAllUsers(function(IUser $user) use ($authorId, $event, $notification) {
+		$this->userManager->callForAllUsers(function (IUser $user) use ($authorId, $event, $notification) {
 			$event->setAffectedUser($user->getUID());
 			$this->activityManager->publish($event);
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -126,7 +126,7 @@ class PageController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function add($subject, $message) {
-		$timeStamp = time();
+		$timeStamp = \time();
 		try {
 			$announcement = $this->manager->announce($subject, $message, $this->userId, $timeStamp);
 		} catch (\InvalidArgumentException $e) {

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -31,7 +31,7 @@ class Manager {
 	/**
 	 * @param IDBConnection $connection
 	 */
-	public function __construct(IDBConnection $connection){
+	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;
 	}
 
@@ -45,8 +45,8 @@ class Manager {
 	 * @throws \InvalidArgumentException when the subject is empty or invalid
 	 */
 	public function announce($subject, $message, $user, $time, $parseStrings = true) {
-		$subject = trim($subject);
-		$message = trim($message);
+		$subject = \trim($subject);
+		$message = \trim($message);
 		if (isset($subject[512])) {
 			throw new \InvalidArgumentException('Invalid subject', 1);
 		}
@@ -149,7 +149,6 @@ class Manager {
 
 		$result = $query->execute();
 
-
 		$announcements = [];
 		while ($row = $result->fetch()) {
 			$announcements[] = [
@@ -162,7 +161,6 @@ class Manager {
 		}
 		$result->closeCursor();
 
-
 		return $announcements;
 	}
 
@@ -171,7 +169,7 @@ class Manager {
 	 * @return string
 	 */
 	protected function parseMessage($message) {
-		return str_replace("\n", '<br />', str_replace(['<', '>'], ['&lt;', '&gt;'], $message));
+		return \str_replace("\n", '<br />', \str_replace(['<', '>'], ['&lt;', '&gt;'], $message));
 	}
 
 	/**
@@ -179,6 +177,6 @@ class Manager {
 	 * @return string
 	 */
 	protected function parseSubject($subject) {
-		return str_replace("\n", ' ', str_replace(['<', '>'], ['&lt;', '&gt;'], $subject));
+		return \str_replace("\n", ' ', \str_replace(['<', '>'], ['&lt;', '&gt;'], $subject));
 	}
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -21,7 +21,6 @@
 
 namespace OCA\AnnouncementCenter\Notification;
 
-
 use OCA\AnnouncementCenter\Manager;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -76,10 +75,10 @@ class Notifier implements INotifier {
 				}
 
 				$announcement = $this->manager->getAnnouncement($notification->getObjectId(), false);
-				$params[] = str_replace("\n", ' ', $announcement['subject']);
+				$params[] = \str_replace("\n", ' ', $announcement['subject']);
 
 				// only set message if present
-				if(!empty($announcement['message'])) {
+				if (!empty($announcement['message'])) {
 					$notification->setParsedMessage($announcement['message']);
 				}
 

--- a/templates/main.php
+++ b/templates/main.php
@@ -11,8 +11,8 @@ style('announcementcenter', 'style');
 	<div id="app-content">
 		<div id="app-content-wrapper">
 			<?php if ($_['is_admin']) {
-				print_unescaped($this->inc('part.add'));
-			} ?>
+	print_unescaped($this->inc('part.add'));
+} ?>
 
 			<div id="emptycontent" class="<?php if ($_['is_admin']): ?>emptycontent-admin <?php endif; ?>hidden">
 				<h2><?php p($l->t('No Announcements')); ?></h2>

--- a/tests/Activity/ExtensionTest.php
+++ b/tests/Activity/ExtensionTest.php
@@ -55,8 +55,8 @@ class ExtensionTest extends TestCase {
 			->getMock();
 		$this->l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
-				return vsprintf($string, $args);
+			->willReturnCallback(function ($string, $args) {
+				return \vsprintf($string, $args);
 			});
 		$this->factory = $this->getMockBuilder('OCP\L10N\IFactory')
 			->disableOriginalConstructor()

--- a/tests/AppInfo/AppTest.php
+++ b/tests/AppInfo/AppTest.php
@@ -64,8 +64,8 @@ class AppTest extends TestCase {
 			->getMock();
 		$this->language->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
-				return vsprintf($string, $args);
+			->willReturnCallback(function ($string, $args) {
+				return \vsprintf($string, $args);
 			});
 
 		$this->overwriteService('NavigationManager', $this->navigationManager);
@@ -88,7 +88,7 @@ class AppTest extends TestCase {
 	public function testAppActivity() {
 		$this->activityManager->expects($this->once())
 			->method('registerExtension')
-			->willReturnCallback(function($closure) {
+			->willReturnCallback(function ($closure) {
 				$this->assertInstanceOf('\Closure', $closure);
 				$navigation = $closure();
 				$this->assertInstanceOf('\OCA\AnnouncementCenter\Activity\Extension', $navigation);
@@ -105,7 +105,7 @@ class AppTest extends TestCase {
 
 		$this->notificationManager->expects($this->once())
 			->method('registerNotifier')
-			->willReturnCallback(function($closureNotifier, $closureInfo) {
+			->willReturnCallback(function ($closureNotifier, $closureInfo) {
 				$this->assertInstanceOf('\Closure', $closureNotifier);
 				$notifier = $closureNotifier();
 				$this->assertInstanceOf('\OCA\AnnouncementCenter\Notification\Notifier', $notifier);

--- a/tests/AppInfo/ApplicationTest.php
+++ b/tests/AppInfo/ApplicationTest.php
@@ -21,7 +21,6 @@
 
 namespace OCA\AnnouncementCenter\Tests\AppInfo;
 
-
 use OCA\AnnouncementCenter\AppInfo\Application;
 use OCA\AnnouncementCenter\Tests\TestCase;
 
@@ -50,9 +49,9 @@ class ApplicationTest extends TestCase {
 	}
 
 	public function dataContainerQuery() {
-		return array(
-			array('PageController', 'OCA\AnnouncementCenter\Controller\PageController'),
-		);
+		return [
+			['PageController', 'OCA\AnnouncementCenter\Controller\PageController'],
+		];
 	}
 
 	/**

--- a/tests/AppInfo/RoutesTest.php
+++ b/tests/AppInfo/RoutesTest.php
@@ -28,6 +28,6 @@ class RoutesTest extends TestCase {
 		$this->assertCount(1, $routes);
 		$this->assertArrayHasKey('routes', $routes);
 		$this->assertInternalType('array', $routes['routes']);
-		$this->assertGreaterThanOrEqual(1, sizeof($routes['routes']));
+		$this->assertGreaterThanOrEqual(1, \sizeof($routes['routes']));
 	}
 }

--- a/tests/BackgroundJobTest.php
+++ b/tests/BackgroundJobTest.php
@@ -122,7 +122,6 @@ class BackgroundJobTest extends TestCase {
 		}
 
 		$this->invokePrivate($job, 'run', [['id' => $id]]);
-
 	}
 
 	protected function getUserMock($uid, $displayName) {
@@ -212,7 +211,7 @@ class BackgroundJobTest extends TestCase {
 		$this->userManager->expects($this->once())
 			->method('callForAllUsers')
 			->with($this->anything(), '')
-			->willReturnCallback(function($callback) {
+			->willReturnCallback(function ($callback) {
 				$users = [
 					$this->getUserMock('author', 'User One'),
 					$this->getUserMock('u2', 'User Two'),

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -74,8 +74,8 @@ class PageControllerTest extends TestCase {
 			->getMock();
 		$this->l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
-				return vsprintf($string, $args);
+			->willReturnCallback(function ($string, $args) {
+				return \vsprintf($string, $args);
 			});
 		$this->jobList = $this->getMockBuilder('OCP\BackgroundJob\IJobList')
 			->disableOriginalConstructor()
@@ -206,7 +206,6 @@ class PageControllerTest extends TestCase {
 	 * @param int $id
 	 */
 	public function testDelete($id) {
-
 		$notification = $this->getMockBuilder('OCP\Notification\INotification')
 			->disableOriginalConstructor()
 			->getMock();
@@ -239,7 +238,7 @@ class PageControllerTest extends TestCase {
 	public function dataAddThrows() {
 		return [
 			['', ['error' => 'The subject is too long or empty']],
-			[str_repeat('a', 513), ['error' => 'The subject is too long or empty']],
+			[\str_repeat('a', 513), ['error' => 'The subject is too long or empty']],
 		];
 	}
 
@@ -279,7 +278,7 @@ class PageControllerTest extends TestCase {
 				'author' => 'author',
 				'subject' => 'subject',
 				'message' => 'message',
-				'time' => time(),
+				'time' => \time(),
 				'id' => 10,
 			]);
 		$this->userManager->expects($this->once())

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -63,14 +63,14 @@ class ManagerTest extends TestCase {
 	 * @expectedCode 1
 	 */
 	public function testAnnounceSubjectTooLong() {
-		$this->manager->announce(str_repeat('a', 513), '', '', 0);
+		$this->manager->announce(\str_repeat('a', 513), '', '', 0);
 	}
 
 	public function testAnnouncement() {
 		$subject = 'subject' . "\n<html>";
 		$message = 'message' . "\n<html>";
 		$author = 'author';
-		$time = time() - 10;
+		$time = \time() - 10;
 
 		$announcement = $this->manager->announce($subject, $message, $author, $time);
 		$this->assertInternalType('int', $announcement['id']);

--- a/tests/Notification/NotifierTest.php
+++ b/tests/Notification/NotifierTest.php
@@ -55,8 +55,8 @@ class NotifierTest extends TestCase {
 			->getMock();
 		$this->l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
-				return vsprintf($string, $args);
+			->willReturnCallback(function ($string, $args) {
+				return \vsprintf($string, $args);
 			});
 		$this->factory = $this->getMockBuilder('OCP\L10N\IFactory')
 			->disableOriginalConstructor()
@@ -189,7 +189,7 @@ class NotifierTest extends TestCase {
 		$subject = 'subject' . "\n<html>";
 		$message = 'message' . "\n<html>";
 		$author = 'author';
-		$time = time() - 10;
+		$time = \time() - 10;
 
 		$announcement = $this->manager->announce($subject, $message, $author, $time);
 		$this->assertInternalType('int', $announcement['id']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,7 +54,6 @@ abstract class TestCase extends \Test\TestCase {
 				return $oldService;
 			});
 
-
 			unset($this->services[$name]);
 			return true;
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,8 +19,8 @@
  *
  */
 
-if (!defined('PHPUNIT_RUN')) {
-	define('PHPUNIT_RUN', 1);
+if (!\defined('PHPUNIT_RUN')) {
+	\define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__.'/../../../lib/base.php';
@@ -34,7 +34,7 @@ require_once __DIR__.'/../../../lib/base.php';
 // Fix for "Autoload path not allowed: .../announcementcenter/tests/testcase.php"
 \OC_App::loadApp('announcementcenter');
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+if (!\class_exists('PHPUnit_Framework_TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 


### PR DESCRIPTION
Fixes #105 

Add coding standard test in drone for php versions 7.1 and 5.6
Fix the code to comply with `owncloud coding standard`