### PR TITLE
Adjust getMock call

### DIFF
--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -113,7 +113,9 @@ class NotifierTest extends TestCase {
 	 * @return \OCP\IUser|\PHPUnit\Framework\MockObject\Builder\InvocationMocker
 	 */
 	protected function getUserMock() {
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$user->expects($this->once())
 			->method('getDisplayName')
 			->willReturn('Author');


### PR DESCRIPTION
with PHPUnit6 there is a unit test fail:
```
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.27-1+ubuntu16.04.1+deb.sury.org+1
Configuration: /var/www/owncloud/apps/announcementcenter/phpunit.xml
Error:         No code coverage driver is available

.........................................................W        58 / 58 (100%)

Time: 310 ms, Memory: 16.00MB

There was 1 warning:

1) Warning
The data provider specified for OCA\AnnouncementCenter\Tests\Unit\Notification\NotifierTest::testPrepare is invalid.
Call to undefined method OCA\AnnouncementCenter\Tests\Unit\Notification\NotifierTest::getMock()

WARNINGS!
Tests: 58, Assertions: 126, Warnings: 1.
make: *** [test-php-unit] Error 1
Makefile:108: recipe for target 'test-php-unit' failed
```

Fix it.