### PR TITLE
phpunit enable failOnRisky

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit bootstrap="../../tests/bootstrap.php"
 		 strict="true"
 		 verbose="true"
+		 failOnRisky="true"
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"


### PR DESCRIPTION
PHPUnit6 reports more "risky" tests (that do not make any assertions).

Enable `failOnRisky` so that we know in CI if that happens.