### PR TITLE
Change phpunit strict to beStrictAboutOutputDuringTests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="../../tests/bootstrap.php"
-		 strict="true"
+		 beStrictAboutOutputDuringTests="true"
 		 verbose="true"
 		 failOnRisky="true"
 		 failOnWarning="true"
@@ -8,9 +8,11 @@
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 >
-	<testsuite name='unit'>
-		<directory suffix='Test.php'>./tests/Unit</directory>
-	</testsuite>
+	<testsuites>
+		<testsuite name='unit'>
+			<directory suffix='Test.php'>./tests/Unit</directory>
+		</testsuite>
+	</testsuites>
 	<!-- filters for code coverage -->
 	<filter>
 		<whitelist>


### PR DESCRIPTION
Fix similar to https://github.com/owncloud/activity/pull/808

And while we are here, it is nice to put the `testsuite` inside a `testsuites` section.
(that is required if there are multiple test suites to define, but currently optional if there is only 1 tes suite)
