### PR TITLE
[Tests-Only] Fix unit tests related to core issue 37358 and core PR 37103

### DIFF
--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -140,7 +140,8 @@ class PageControllerTest extends TestCase {
 				1,
 				[
 					['id' => 1337, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
-				], [],
+				],
+				[],
 				[
 					['id' => 1337, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
 				],
@@ -151,7 +152,7 @@ class PageControllerTest extends TestCase {
 					['id' => 23, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
 				],
 				[
-					['author1', $this->getUserMock('author1', 'Author One')],
+					['author1', false, $this->getUserMock('author1', 'Author One')],
 				],
 				[
 					['id' => 23, 'author' => 'Author One', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],


### PR DESCRIPTION
Part of issue https://github.com/owncloud/core/issues/37358

The signature of core `lib/private/User/Manager.php` `get()` changed to have a new 2nd parameter.
See core PR https://github.com/owncloud/core/pull/37103

Adjust unit tests so that the mocking of userManager matches the way that phpunit sees the calls. Even though the new parameter is optional (has a default value), phpunit sees the call happening with the parameter having been set to its default value `false`