### PR TITLE
[tests-only] Bump phan to major version 3

### DIFF
--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^2.7"
+        "phan/phan": "^3.2"
     }
 }


### PR DESCRIPTION
phan V3 has been out for a while. V2 reports:
```
Consider upgrading to Phan 3, which has the latest features and bug fixes (supports execution with PHP 7.2+)
```
and we meet that PHP requirement these days.
