### PR TITLE
Use relative url instead of absoulute url

### DIFF
--- a/lib/BackgroundJob.php
+++ b/lib/BackgroundJob.php
@@ -97,7 +97,7 @@ class BackgroundJob extends QueuedJob {
 			->setDateTime($dateTime)
 			->setObject('announcement', (string) $id)
 			->setSubject('announced', [$authorId])
-			->setLink($this->urlGenerator->linkToRouteAbsolute('announcementcenter.page.index'));
+			->setLink($this->urlGenerator->linkToRoute('announcementcenter.page.index'));
 
 		$this->userManager->callForAllUsers(function (IUser $user) use ($authorId, $event, $notification) {
 			$event->setAffectedUser($user->getUID());


### PR DESCRIPTION
Related to owncloud/enterprise#4250 as notifications URLs shouldn't be absolute to prevent problems with CORS.