### PR TITLE
[tests-only] Add 'count' to  phpstan.neon

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -94,7 +94,7 @@ def main(ctx):
     return before + coverageTests + afterCoverageTests + nonCoverageTests + stages + after
 
 def beforePipelines(ctx):
-    return codestyle(ctx) + jscodestyle(ctx) + cancelPreviousBuilds() + phpstan(ctx) + phan(ctx) + phplint(ctx) + checkStarlark()
+    return validateDailyTarballBuild() + codestyle(ctx) + jscodestyle(ctx) + cancelPreviousBuilds() + phpstan(ctx) + phan(ctx) + phplint(ctx) + checkStarlark()
 
 def coveragePipelines(ctx):
     # All unit test pipelines that have coverage or other test analysis reported
@@ -358,6 +358,7 @@ def phan(ctx):
 
     default = {
         "phpVersions": [DEFAULT_PHP_VERSION],
+        "extraApps": {},
     }
 
     if "defaults" in config:
@@ -396,6 +397,7 @@ def phan(ctx):
                 },
                 "steps": skipIfUnchanged(ctx, "lint") +
                          installCore(ctx, "daily-master-qa", "sqlite", False) +
+                         installExtraApps(phpVersion, params["extraApps"], False) +
                          [
                              {
                                  "name": "phan",
@@ -867,6 +869,7 @@ def acceptance(ctx):
         "databases": ["mariadb:10.2"],
         "esVersions": ["none"],
         "federatedServerNeeded": False,
+        "federatedServerVersion": "",
         "filterTags": "",
         "logLevel": "2",
         "emailNeeded": False,
@@ -1102,7 +1105,11 @@ def acceptance(ctx):
                         environment["S3_TYPE"] = "ceph"
                     if (testConfig["scalityS3"] != False):
                         environment["S3_TYPE"] = "scality"
+
                 federationDbSuffix = "-federated"
+
+                if len(testConfig["federatedServerVersion"]) == 0:
+                    testConfig["federatedServerVersion"] = testConfig["server"]
 
                 result = {
                     "kind": "pipeline",
@@ -1115,7 +1122,7 @@ def acceptance(ctx):
                     "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                              installCore(ctx, testConfig["server"], testConfig["database"], testConfig["useBundledApp"]) +
                              installTestrunner(ctx, DEFAULT_PHP_VERSION, testConfig["useBundledApp"]) +
-                             (installFederated(testConfig["server"], phpVersionForDocker, testConfig["logLevel"], testConfig["database"], federationDbSuffix) + owncloudLog("federated") if testConfig["federatedServerNeeded"] else []) +
+                             (installFederated(testConfig["federatedServerVersion"], phpVersionForDocker, testConfig["logLevel"], testConfig["database"], federationDbSuffix) + owncloudLog("federated") if testConfig["federatedServerNeeded"] else []) +
                              installAppPhp(ctx, phpVersionForDocker) +
                              installAppJavaScript(ctx) +
                              installExtraApps(phpVersionForDocker, testConfig["extraApps"]) +
@@ -1127,6 +1134,7 @@ def acceptance(ctx):
                              testConfig["extraSetup"] +
                              waitForServer(testConfig["federatedServerNeeded"]) +
                              waitForEmailService(testConfig["emailNeeded"]) +
+                             waitForSamba(testConfig["extraServices"]) +
                              fixPermissions(phpVersionForDocker, testConfig["federatedServerNeeded"], params["selUserNeeded"]) +
                              waitForBrowserService(testConfig["browser"]) +
                              [
@@ -1155,7 +1163,7 @@ def acceptance(ctx):
                                 testConfig["extraServices"] +
                                 owncloudService(testConfig["server"], phpVersionForDocker, "server", dir["server"], testConfig["ssl"], testConfig["xForwardedFor"]) +
                                 ((
-                                    owncloudService(testConfig["server"], phpVersionForDocker, "federated", dir["federated"], testConfig["ssl"], testConfig["xForwardedFor"]) +
+                                    owncloudService(testConfig["federatedServerVersion"], phpVersionForDocker, "federated", dir["federated"], testConfig["ssl"], testConfig["xForwardedFor"]) +
                                     databaseServiceForFederation(testConfig["database"], federationDbSuffix)
                                 ) if testConfig["federatedServerNeeded"] else []),
                     "depends_on": [],
@@ -1427,6 +1435,26 @@ def waitForEmailService(emailNeeded):
 
     return []
 
+def waitForSamba(extraServices):
+    foundSamba = False
+
+    for extraService in extraServices:
+        # each service entry should be a key-value dictionary that has at least a "name" key
+        # if there is a "samba" service specified, then we need to wait for it to start.
+        if (extraService["name"] == "samba"):
+            foundSamba = True
+
+    if (foundSamba):
+        return [{
+            "name": "wait-for-samba",
+            "image": OC_CI_WAIT_FOR,
+            "commands": [
+                "wait-for -it samba:139,samba:445 -t 300",
+            ],
+        }]
+
+    return []
+
 def ldapService(ldapNeeded):
     if ldapNeeded:
         return [{
@@ -1653,7 +1681,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         ] if not useBundledApp else []),
     }]
 
-def installExtraApps(phpVersion, extraApps):
+def installExtraApps(phpVersion, extraApps, enableExtraApps = True):
     commandArray = []
     for app, command in extraApps.items():
         commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
@@ -1662,9 +1690,10 @@ def installExtraApps(phpVersion, extraApps):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)
         commandArray.append("cd %s" % dir["server"])
-        commandArray.append("php occ a:l")
-        commandArray.append("php occ a:e %s" % app)
-        commandArray.append("php occ a:l")
+        if (enableExtraApps):
+            commandArray.append("php occ a:l")
+            commandArray.append("php occ a:e %s" % app)
+            commandArray.append("php occ a:l")
 
     if (commandArray == []):
         return []
@@ -1823,7 +1852,7 @@ def setupElasticSearch(esVersion):
             "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
             "commands": [
                 "cd %s" % dir["server"],
-                "php occ config:app:set search_elastic servers --value elasticsearch",
+                "php occ config:app:set search_elastic servers --value http://elasticsearch:9200",
                 "php occ search:index:reset --force",
             ],
         },
@@ -2204,3 +2233,33 @@ def skipIfUnchanged(ctx, type):
         return [skip_step]
 
     return []
+
+def validateDailyTarballBuild():
+    if "validateDailyTarball" not in config:
+        return []
+
+    if not config["validateDailyTarball"]:
+        return []
+
+    pipeline = {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "check-tarball-build-date",
+        "steps": [{
+            "name": "check-build-date",
+            "image": OC_CI_ALPINE,
+            "commands": [
+                "chmod +x ./tests/drone/check-daily-update.sh",
+                "./tests/drone/check-daily-update.sh %s %s" % ("daily-master", "daily-master-qa"),
+            ],
+        }],
+        "depends_on": [],
+        "trigger": {
+            "ref": [],
+        },
+    }
+
+    for branch in config["branches"]:
+        pipeline["trigger"]["ref"].append("refs/heads/%s" % branch)
+
+    return [pipeline]

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
   },
   "require-dev": {
-    "bamarni/composer-bin-plugin": "^1.4"
+    "bamarni/composer-bin-plugin": "^1.8"
   },
   "extra": {
     "bamarni-bin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08bce8888d90a8cac412ebd890217822",
+    "content-hash": "bc6552c2069bffe709f2c256d6a96bef",
     "packages": [],
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.8.0",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "24764700027bcd3cb072e5f8005d4a150fe714fe"
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/24764700027bcd3cb072e5f8005d4a150fe714fe",
-                "reference": "24764700027bcd3cb072e5f8005d4a150fe714fe",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
                 "shasum": ""
             },
             "require": {
@@ -32,9 +32,9 @@
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
                 "phpunit/phpunit": "^8.5 || ^9.5",
-                "symfony/console": "^5.4.7 || ^6.0.7",
-                "symfony/finder": "^5.4.7 || ^6.0.7",
-                "symfony/process": "^5.4.7 || ^6.0.7"
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -60,9 +60,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.0"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
             },
-            "time": "2022-07-14T10:29:51+00:00"
+            "time": "2022-10-31T08:38:03+00:00"
         }
     ],
     "aliases": [],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,4 @@ parameters:
     -
       message: '#Property OCA\\AnnouncementCenter\\Controller\\PageController::\$connection is never read, only written.#'
       path: lib/Controller/PageController.php
+      count: 1


### PR DESCRIPTION
If the count of a `phpstan` message changes, then we will notice in the PR and investigate.
So having `count` specified in `ignoreErrors` is better. (that is already done in other apps such as activity and admin_audit)

Also:
- bump composer dependency
- apply latest .drone.star changes from activity app